### PR TITLE
feat: add Next.js config helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # next-video-site
+
+## Configuration
+
+### Public runtime config
+
+The app reads public configuration values from `next.config.js`. These values are
+exposed to the browser and should only contain non‑sensitive information.
+
+Required variables:
+
+- `NEXT_PUBLIC_API_BASE_URL` – Base URL for public API requests.
+
+### Secure parameters
+
+Sensitive values are loaded from AWS Systems Manager Parameter Store at runtime
+using a small helper with in-memory caching. During development the helper falls
+back to values defined in a local `.env.local` file.
+
+Required secure parameters:
+
+- `VIDEO_API_KEY` – API key for the video service.
+
+For local development create an `.env.local` file:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/api
+VIDEO_API_KEY=dev-api-key
+```
+
+Ensure AWS credentials with permission to read the parameters are available in
+production environments.

--- a/lib/publicConfig.js
+++ b/lib/publicConfig.js
@@ -1,0 +1,10 @@
+/**
+ * Helper to read the public runtime configuration exposed by next.config.js.
+ */
+function loadPublicConfig() {
+  const configModule = require('../next.config');
+  const config = typeof configModule === 'function' ? configModule() : configModule;
+  return config.publicRuntimeConfig || {};
+}
+
+module.exports = { loadPublicConfig };

--- a/lib/secureConfig.js
+++ b/lib/secureConfig.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const cache = {};
+
+function parseEnv(content) {
+  const env = {};
+  content.split(/\r?\n/).forEach(line => {
+    const match = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$/);
+    if (match) {
+      env[match[1]] = match[2];
+    }
+  });
+  return env;
+}
+
+function loadLocalEnv() {
+  if (process.env.NODE_ENV === 'development') {
+    const envPath = path.join(process.cwd(), '.env.local');
+    if (fs.existsSync(envPath)) {
+      const file = fs.readFileSync(envPath, 'utf8');
+      const parsed = parseEnv(file);
+      Object.assign(process.env, parsed);
+    }
+  }
+}
+
+/**
+ * Retrieve secure parameter from AWS SSM Parameter Store.
+ * Results are cached in memory. In development the value falls back to
+ * `.env.local` if the parameter is not available from SSM.
+ *
+ * @param {string} name Parameter name
+ * @returns {Promise<string>} resolved parameter value
+ */
+async function getSecureParameter(name) {
+  if (cache[name]) {
+    return cache[name];
+  }
+
+  loadLocalEnv();
+
+  if (process.env.NODE_ENV === 'development' && process.env[name]) {
+    cache[name] = process.env[name];
+    return cache[name];
+  }
+
+  const { SSMClient, GetParameterCommand } = require('@aws-sdk/client-ssm');
+  const client = new SSMClient({});
+  const command = new GetParameterCommand({
+    Name: name,
+    WithDecryption: true
+  });
+  const response = await client.send(command);
+  const value = response.Parameter && response.Parameter.Value;
+  cache[name] = value;
+  return value;
+}
+
+module.exports = { getSecureParameter };

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  publicRuntimeConfig: {
+    /**
+     * Base URL for public API calls.
+     * Exposed to the browser via Next.js runtime configuration.
+     */
+    API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL || ''
+  }
+};


### PR DESCRIPTION
## Summary
- add `next.config.js` with public runtime configuration
- helper to read public config
- helper to fetch secure parameters from AWS SSM with caching and `.env.local` fallback
- document required parameters

## Testing
- `NEXT_PUBLIC_API_BASE_URL=https://api.example.com node -e "console.log(require('./lib/publicConfig').loadPublicConfig())"`
- `echo 'VIDEO_API_KEY=dev-api-key' > .env.local && NODE_ENV=development node -e "require('./lib/secureConfig').getSecureParameter('VIDEO_API_KEY').then(v=>console.log('value:', v))" && rm .env.local`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edef04848328b0bde5bb76a498f2