### PR TITLE
Add error handling utilities and logging hooks

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect } from 'react';
+import { getUserMessage } from '../lib/errors';
+import { useErrorLogger } from '../hooks/use-error-logger';
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  const logError = useErrorLogger();
+
+  useEffect(() => {
+    logError(error);
+  }, [error, logError]);
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Something went wrong</h1>
+      <p>{getUserMessage(error)}</p>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>404 - Page Not Found</h1>
+      <p>The page you are looking for could not be found.</p>
+    </div>
+  );
+}

--- a/hooks/use-error-logger.ts
+++ b/hooks/use-error-logger.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useCallback } from 'react';
+
+function serializeError(error: unknown) {
+  if (error instanceof Error) {
+    const { name, message, stack } = error;
+    return { name, message, stack };
+  }
+  return { message: String(error) };
+}
+
+export function useErrorLogger() {
+  return useCallback(async (error: unknown) => {
+    try {
+      await fetch(process.env.NEXT_PUBLIC_ERROR_LOG_URL ?? '/api/errors', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: serializeError(error) }),
+      });
+    } catch {
+      // Ignore logging failures
+    }
+  }, []);
+}

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,19 @@
+export class AppError<TCode extends string = string> extends Error {
+  public readonly code: TCode;
+  public readonly userMessage: string;
+
+  constructor(code: TCode, userMessage: string, options?: ErrorOptions) {
+    super(userMessage, options);
+    this.name = 'AppError';
+    this.code = code;
+    this.userMessage = userMessage;
+  }
+}
+
+export function isAppError(error: unknown): error is AppError {
+  return error instanceof AppError;
+}
+
+export function getUserMessage(error: unknown): string {
+  return isAppError(error) ? error.userMessage : 'An unexpected error occurred.';
+}


### PR DESCRIPTION
## Summary
- add `AppError` class with user-safe messages
- add `useErrorLogger` hook to send errors to persistence API
- create `app/error.tsx` and `app/not-found.tsx` pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edf1033c832893b21148ccdc68ad