### PR TITLE
Add S3 versioning and lifecycle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # next-video-site
+
+Infrastructure snippets for the video site.
+
+- **cdk/storage-stack.ts** – S3 bucket with versioning and lifecycle rules
+- **cdk/bucket-policy.json** – bucket policy enforcing encryption and TLS
+- **docs/recovery.md** – recovery procedures for Glacier and object versions

--- a/cdk/bucket-policy.json
+++ b/cdk/bucket-policy.json
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyUnEncryptedUploads",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/*",
+      "Condition": {
+        "StringNotEquals": {
+          "s3:x-amz-server-side-encryption": "aws:kms"
+        }
+      }
+    },
+    {
+      "Sid": "EnforceTLS",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::YOUR_BUCKET_NAME",
+        "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+      ],
+      "Condition": {
+        "Bool": { "aws:SecureTransport": "false" }
+      }
+    }
+  ]
+}

--- a/cdk/storage-stack.ts
+++ b/cdk/storage-stack.ts
@@ -1,0 +1,24 @@
+import { Stack, StackProps, Duration } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
+export class StorageStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const inputBucket = new s3.Bucket(this, 'InputBucket', {
+      versioned: true,
+      lifecycleRules: [
+        {
+          transitions: [
+            {
+              storageClass: s3.StorageClass.GLACIER,
+              transitionAfter: Duration.days(30),
+            },
+          ],
+          abortIncompleteMultipartUploadAfter: Duration.days(7),
+        },
+      ],
+    });
+  }
+}

--- a/docs/recovery.md
+++ b/docs/recovery.md
@@ -1,0 +1,20 @@
+# Object Recovery Guide
+
+This guide covers restoring objects from the versioned input bucket.
+
+## Restoring a Previous Version
+1. Browse object versions in the S3 console.
+2. Select the desired version and choose **Restore**.
+3. Copy or download the restored version.
+
+## Retrieving from Glacier
+Objects transition to Glacier after 30 days. To access them:
+1. In the S3 console, choose the object and select **Initiate restore**.
+2. Pick a retrieval tier (Expedited, Standard, or Bulk) and a retention period.
+3. Wait for the restore to complete, then download the temporary copy.
+
+## Cancelling Lifecycle Rules
+If recovery requires disabling the lifecycle rules:
+1. Open the bucket's **Management** tab.
+2. Delete or pause the rules that transition to Glacier or delete aborted uploads.
+3. Re-enable the rules after recovery operations are complete.


### PR DESCRIPTION
## Summary
- add CDK stack with versioned bucket and lifecycle rules
- include bucket policy enforcing encryption and TLS
- document recovery steps for object versions and Glacier

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edf9299c8328a4b74d76fbba22ba