### PR TITLE
Add MediaConvert HLS/DASH template and example job

### DIFF
--- a/example_job.json
+++ b/example_job.json
@@ -1,0 +1,19 @@
+{
+  "Role": "arn:aws:iam::ACCOUNT:role/MediaConvert_Default_Role",
+  "JobTemplate": "HlsDashAacCmaf",
+  "Settings": {
+    "Inputs": [
+      {
+        "FileInput": "s3://STLS-vod-assets/input/example.mp4",
+        "AudioSelectors": {
+          "Audio Selector 1": {
+            "DefaultSelection": "DEFAULT"
+          }
+        }
+      }
+    ]
+  },
+  "UserMetadata": {
+    "project": "stls-vod"
+  }
+}

--- a/mediaconvert_template.json
+++ b/mediaconvert_template.json
@@ -1,0 +1,92 @@
+{
+  "Name": "HlsDashAacCmaf",
+  "Description": "HLS and DASH outputs using CMAF segments, AAC audio, and KMS encryption",
+  "Settings": {
+    "TimecodeConfig": {"Source": "ZEROBASED"},
+    "OutputGroups": [
+      {
+        "Name": "Apple HLS",
+        "Outputs": [
+          {
+            "VideoDescriptionName": "video_main",
+            "AudioDescriptionNames": ["audio_main"],
+            "ContainerSettings": {"Container": "M3U8"},
+            "NameModifier": "_hls"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "HLS_GROUP_SETTINGS",
+          "HlsGroupSettings": {
+            "SegmentLength": 6,
+            "SegmentControl": "SEGMENTED_FILES",
+            "SegmentType": "CMAF",
+            "Destination": "s3://STLS-vod-assets/hls/",
+            "DestinationSettings": {
+              "S3Settings": {
+                "Encryption": {
+                  "Mode": "SSEKMS",
+                  "KmsKeyArn": "arn:aws:kms:REGION:ACCOUNT:key/CMK-ID"
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "Name": "MPEG-DASH",
+        "Outputs": [
+          {
+            "VideoDescriptionName": "video_main",
+            "AudioDescriptionNames": ["audio_main"],
+            "ContainerSettings": {"Container": "MP4"},
+            "NameModifier": "_dash"
+          }
+        ],
+        "OutputGroupSettings": {
+          "Type": "DASH_ISO_GROUP_SETTINGS",
+          "DashIsoGroupSettings": {
+            "SegmentLength": 6,
+            "FragmentLength": 2,
+            "Destination": "s3://STLS-vod-assets/dash/",
+            "DestinationSettings": {
+              "S3Settings": {
+                "Encryption": {
+                  "Mode": "SSEKMS",
+                  "KmsKeyArn": "arn:aws:kms:REGION:ACCOUNT:key/CMK-ID"
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "VideoDescriptions": [
+      {
+        "Name": "video_main",
+        "CodecSettings": {
+          "Codec": "H_264",
+          "H264Settings": {
+            "RateControlMode": "CBR",
+            "Bitrate": 5000000,
+            "GopSize": 2,
+            "GopSizeUnits": "SECONDS"
+          }
+        }
+      }
+    ],
+    "AudioDescriptions": [
+      {
+        "Name": "audio_main",
+        "AudioSourceName": "Audio Selector 1",
+        "CodecSettings": {
+          "Codec": "AAC",
+          "AacSettings": {
+            "Bitrate": 96000,
+            "CodingMode": "CODING_MODE_2_0",
+            "SampleRate": 48000
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add MediaConvert job template for HLS and DASH outputs using CMAF segments and KMS encryption
- provide example job JSON referencing the template

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edfa36e48328a24974b7928fa9b9