### PR TITLE
Add video processing workflow with EventBridge trigger and DLQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # next-video-site
+
+This repository contains an example workflow for processing uploaded videos using AWS Step Functions. The workflow is triggered by an S3 object arrival via EventBridge and performs the following steps:
+
+1. Validates the input file.
+2. Submits an AWS Elemental MediaConvert job.
+3. Waits for job completion and updates a DynamoDB table.
+4. Publishes errors to an SNS topic and routes failed events to an SQS dead-letter queue.
+
+Infrastructure templates live in `infra/`:
+
+- `state-machine.asl.json` defines the Step Functions state machine with retry policies and error handling.
+- `eventbridge-rule.json` provides an EventBridge rule that targets the state machine and includes DLQ and retry settings.
+
+These files are starting points and require proper resource ARNs and IAM roles before deployment.

--- a/infra/eventbridge-rule.json
+++ b/infra/eventbridge-rule.json
@@ -1,0 +1,34 @@
+{
+  "Resources": {
+    "VideoProcessingDLQ": {
+      "Type": "AWS::SQS::Queue"
+    },
+    "VideoUploadRule": {
+      "Type": "AWS::Events::Rule",
+      "Properties": {
+        "EventPattern": {
+          "source": ["aws.s3"],
+          "detail-type": ["Object Created"],
+          "detail": {
+            "bucket": {
+              "name": ["input-video-bucket"]
+            }
+          }
+        },
+        "Targets": [
+          {
+            "Arn": { "Ref": "VideoProcessingStateMachine" },
+            "Id": "VideoProcessingStateMachineTarget",
+            "DeadLetterConfig": {
+              "Arn": { "Fn::GetAtt": ["VideoProcessingDLQ", "Arn"] }
+            },
+            "RetryPolicy": {
+              "MaximumEventAgeInSeconds": 3600,
+              "MaximumRetryAttempts": 2
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/infra/state-machine.asl.json
+++ b/infra/state-machine.asl.json
@@ -1,0 +1,170 @@
+{
+  "Comment": "Video processing workflow triggered by S3 object via EventBridge.",
+  "StartAt": "ValidateInput",
+  "States": {
+    "ValidateInput": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:REGION:ACCOUNT:function:ValidateInput",
+      "Next": "SubmitMediaConvert",
+      "Retry": [
+        {
+          "ErrorEquals": ["Lambda.ServiceException", "Lambda.AWSLambdaException", "Lambda.SdkClientException"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "NotifyError"
+        }
+      ]
+    },
+    "SubmitMediaConvert": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::mediaconvert:createJob",
+      "Parameters": {
+        "Role": "arn:aws:iam::ACCOUNT:role/MediaConvertRole",
+        "Settings": {
+          "Inputs": [
+            {
+              "FileInput.$": "$.detail.object.key"
+            }
+          ]
+        }
+      },
+      "ResultPath": "$.Job",
+      "Next": "WaitForJob",
+      "Retry": [
+        {
+          "ErrorEquals": ["MediaConvert.ServiceException", "States.TaskFailed"],
+          "IntervalSeconds": 10,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "NotifyError"
+        }
+      ]
+    },
+    "WaitForJob": {
+      "Type": "Wait",
+      "Seconds": 30,
+      "Next": "CheckJob"
+    },
+    "CheckJob": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::mediaconvert:getJob",
+      "Parameters": {
+        "Id.$": "$.Job.Job.Id"
+      },
+      "ResultPath": "$.Job",
+      "Next": "JobFinished?",
+      "Retry": [
+        {
+          "ErrorEquals": ["MediaConvert.ServiceException", "States.TaskFailed"],
+          "IntervalSeconds": 10,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "NotifyError"
+        }
+      ]
+    },
+    "JobFinished?": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.Job.Job.Status",
+          "StringEquals": "COMPLETE",
+          "Next": "UpdateStatus"
+        },
+        {
+          "Variable": "$.Job.Job.Status",
+          "StringEquals": "ERROR",
+          "Next": "NotifyError"
+        }
+      ],
+      "Default": "WaitForJob"
+    },
+    "UpdateStatus": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName": "VideoJobs",
+        "Key": {
+          "jobId": {
+            "S.$": "$.Job.Job.Id"
+          }
+        },
+        "UpdateExpression": "SET #s = :s",
+        "ExpressionAttributeNames": {
+          "#s": "status"
+        },
+        "ExpressionAttributeValues": {
+          ":s": {
+            "S": "COMPLETED"
+          }
+        }
+      },
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "DynamoDB.AmazonDynamoDBException",
+            "DynamoDB.ProvisionedThroughputExceededException",
+            "DynamoDB.ResourceNotFoundException",
+            "States.TaskFailed"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "ResultPath": "$.error",
+          "Next": "NotifyError"
+        }
+      ]
+    },
+    "NotifyError": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sns:publish",
+      "Parameters": {
+        "TopicArn": "arn:aws:sns:REGION:ACCOUNT:VideoProcessingErrors",
+        "Message.$": "States.JsonToString($.error)"
+      },
+      "Next": "SendToDLQ",
+      "Retry": [
+        {
+          "ErrorEquals": ["SNS.InternalError", "States.TaskFailed"],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "SendToDLQ": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::sqs:sendMessage",
+      "Parameters": {
+        "QueueUrl": "https://sqs.REGION.amazonaws.com/ACCOUNT/video-processing-dlq",
+        "MessageBody.$": "States.JsonToString($)"
+      },
+      "End": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- define Step Functions workflow for validating uploads, submitting MediaConvert jobs, polling completion, updating status, and handling errors
- add EventBridge rule to trigger workflow on S3 object create events with retry policy and DLQ
- document workflow and infrastructure files in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edfbda44832882068081291f90d5