### PR TITLE
Add SPEKE 2.0 DRM adapter and KMS interface design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # next-video-site
+
+This repository includes a placeholder SPEKE 2.0 DRM key server adapter and
+pluggable Key Management Service (KMS) interfaces. The components are
+illustrated with Mermaid diagrams and code stubs to guide future
+implementation.
+
+- `src/drm/speke20Adapter.ts` – SPEKE 2.0 key server adapter with provider
+  placeholders.
+- `src/kms/kms.ts` – Secure KMS interface and a placeholder implementation.
+- `docs/kms-design.md` – Architecture diagram and interface description.

--- a/docs/kms-design.md
+++ b/docs/kms-design.md
@@ -1,0 +1,35 @@
+# KMS Interface Design
+
+The application uses a pluggable key management service (KMS) to keep
+cryptographic operations isolated from business logic. The interface
+exposes a minimal set of primitives required by the DRM workflow.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Player
+    participant Adapter as SPEKE Adapter
+    participant KMS
+
+    Player->>Adapter: Request DRM keys
+    Adapter->>KMS: generateDataKey()
+    KMS-->>Adapter: {keyId, plaintext, ciphertext}
+    Adapter->>KMS: encrypt(keyId, contentKey)
+    KMS-->>Adapter: encryptedKey
+    Adapter-->>Player: SPEKE response
+```
+
+## Code Stub
+
+```ts
+export interface KeyManagementService {
+  generateDataKey(keySpec: string): Promise<GeneratedKey>;
+  encrypt(keyId: string, plaintext: Buffer): Promise<Buffer>;
+  decrypt(keyId: string, ciphertext: Buffer): Promise<Buffer>;
+}
+```
+
+Implementations such as `PlaceholderKms` should be replaced with
+production-ready providers that enforce access control, auditing and
+secure key storage.

--- a/src/drm/speke20Adapter.ts
+++ b/src/drm/speke20Adapter.ts
@@ -1,0 +1,57 @@
+export interface SpekeRequest {
+  protectionSystemIds: string[];
+  resourceId: string;
+}
+
+export interface SpekeResponse {
+  keys: Array<{ keyId: string; key: string }>;
+  systemIds: string[];
+}
+
+/**
+ * SPEKE 2.0 DRM key server adapter.
+ *
+ * This class wraps provider specific DRM key server logic
+ * behind a common interface. All provider calls are placeholders
+ * and should be replaced with production implementations.
+ */
+export class SpekeV2KeyServerAdapter {
+  constructor(private provider: DrmProvider) {}
+
+  /**
+   * Retrieve keys for the given request.
+   */
+  async fetchKeys(req: SpekeRequest): Promise<SpekeResponse> {
+    // Placeholder: delegate to provider's DRM key service
+    // In production, this would make network calls to the DRM vendor
+    const providerResponse = await this.provider.getKeys(req);
+
+    return {
+      keys: providerResponse.keys,
+      systemIds: req.protectionSystemIds,
+    };
+  }
+}
+
+/**
+ * Minimal interface for a DRM provider.
+ * Replace with real provider SDK integration.
+ */
+export interface DrmProvider {
+  getKeys(req: SpekeRequest): Promise<SpekeResponse>;
+}
+
+/**
+ * Example placeholder provider returning static keys.
+ */
+export class PlaceholderDrmProvider implements DrmProvider {
+  async getKeys(req: SpekeRequest): Promise<SpekeResponse> {
+    return {
+      keys: req.protectionSystemIds.map((id) => ({
+        keyId: id,
+        key: 'PLACEHOLDER_KEY',
+      })),
+      systemIds: req.protectionSystemIds,
+    };
+  }
+}

--- a/src/kms/kms.ts
+++ b/src/kms/kms.ts
@@ -1,0 +1,43 @@
+/**
+ * Interface describing the capabilities of a Key Management Service.
+ * Implementations should provide secure access to cryptographic keys.
+ */
+export interface KeyManagementService {
+  /** Generate a new data encryption key. */
+  generateDataKey(keySpec: string): Promise<GeneratedKey>;
+  /** Encrypt plaintext with a given key id. */
+  encrypt(keyId: string, plaintext: Buffer): Promise<Buffer>;
+  /** Decrypt ciphertext with a given key id. */
+  decrypt(keyId: string, ciphertext: Buffer): Promise<Buffer>;
+}
+
+export interface GeneratedKey {
+  keyId: string;
+  plaintext: Buffer;
+  ciphertext: Buffer;
+}
+
+/**
+ * Placeholder KMS implementation. Replace with calls to a real
+ * provider such as AWS KMS, Google Cloud KMS, etc.
+ */
+export class PlaceholderKms implements KeyManagementService {
+  async generateDataKey(keySpec: string): Promise<GeneratedKey> {
+    const key = Buffer.from('PLACEHOLDER_KEY');
+    return {
+      keyId: 'placeholder-key-id',
+      plaintext: key,
+      ciphertext: key,
+    };
+  }
+
+  async encrypt(keyId: string, plaintext: Buffer): Promise<Buffer> {
+    // No-op placeholder encryption
+    return plaintext;
+  }
+
+  async decrypt(keyId: string, ciphertext: Buffer): Promise<Buffer> {
+    // No-op placeholder decryption
+    return ciphertext;
+  }
+}


### PR DESCRIPTION
## Summary
- implement placeholder SPEKE 2.0 DRM key server adapter with stub provider
- define secure KMS interface with placeholder implementation
- document KMS architecture with mermaid diagram

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4edfe17b88328a74b31e504d43b7f