### PR TITLE
Add IVS Web Broadcast demo with device selection and stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # next-video-site
+
+Simple demo showing integration of the [Amazon IVS Web Broadcast SDK](https://docs.aws.amazon.com/ivs/latest/LowLatencyUserGuide/broadcast-web.html).
+
+Open `index.html` in a browser to choose audio/video devices and start/stop
+broadcasting with your IVS ingest endpoint and stream key. The page enforces a
+`Creator` role and displays basic network statistics while streaming.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,97 @@
+const roleSelect = document.getElementById('role');
+const enterBtn = document.getElementById('enter');
+const broadcastSection = document.getElementById('broadcast');
+const startBtn = document.getElementById('start');
+const stopBtn = document.getElementById('stop');
+const videoSelect = document.getElementById('videoDevices');
+const audioSelect = document.getElementById('audioDevices');
+const previewEl = document.getElementById('preview');
+const statsEl = document.getElementById('stats');
+const ingestInput = document.getElementById('ingest');
+const streamKeyInput = document.getElementById('streamKey');
+
+let client;
+let statInterval;
+let currentRole;
+
+async function listDevices() {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  videoSelect.innerHTML = '';
+  audioSelect.innerHTML = '';
+  devices.forEach(d => {
+    const option = document.createElement('option');
+    option.value = d.deviceId;
+    option.text = d.label || d.kind;
+    if (d.kind === 'videoinput') videoSelect.appendChild(option);
+    if (d.kind === 'audioinput') audioSelect.appendChild(option);
+  });
+}
+
+enterBtn.addEventListener('click', async () => {
+  currentRole = roleSelect.value;
+  if (currentRole !== 'Creator') {
+    alert('Creator role required to broadcast.');
+    return;
+  }
+  await listDevices();
+  broadcastSection.style.display = 'block';
+});
+
+startBtn.addEventListener('click', async () => {
+  if (currentRole !== 'Creator') {
+    alert('Creator role required to broadcast.');
+    return;
+  }
+
+  client = IVSBroadcastClient.create({
+    ingestEndpoint: ingestInput.value,
+    streamConfig: IVSBroadcastClient.BASIC_LANDSCAPE,
+  });
+
+  const audioStream = await navigator.mediaDevices.getUserMedia({
+    audio: {deviceId: audioSelect.value ? {exact: audioSelect.value} : undefined},
+    video: false,
+  });
+  await client.addAudioInputDevice(audioStream, 'mic1');
+
+  const videoStream = await navigator.mediaDevices.getUserMedia({
+    video: {deviceId: videoSelect.value ? {exact: videoSelect.value} : undefined},
+    audio: false,
+  });
+  await client.addVideoInputDevice(videoStream, 'camera1', {index: 0});
+
+  client.attachPreview(previewEl);
+
+  await client.startBroadcast(streamKeyInput.value);
+
+  startBtn.disabled = true;
+  stopBtn.disabled = false;
+
+  statInterval = setInterval(async () => {
+    const stats = await client.getStats();
+    if (!stats) return;
+    const out = [];
+    stats.forEach(report => {
+      if (report.type === 'outbound-rtp') {
+        out.push({
+          kind: report.kind,
+          packetsSent: report.packetsSent,
+          packetsLost: report.packetsLost,
+          bytesSent: report.bytesSent,
+        });
+      }
+    });
+    statsEl.textContent = JSON.stringify(out, null, 2);
+  }, 1000);
+});
+
+stopBtn.addEventListener('click', async () => {
+  if (client) {
+    await client.stopBroadcast();
+    client = null;
+  }
+  startBtn.disabled = false;
+  stopBtn.disabled = true;
+  statsEl.textContent = '';
+  clearInterval(statInterval);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>IVS Broadcast Demo</title>
+</head>
+<body>
+  <h1>IVS Broadcast Demo</h1>
+  <div id="auth">
+    <label for="role">Role:</label>
+    <select id="role">
+      <option value="Creator">Creator</option>
+      <option value="Viewer">Viewer</option>
+    </select>
+    <button id="enter">Enter</button>
+  </div>
+
+  <div id="broadcast" style="display:none">
+    <div id="config">
+      <label>Camera: <select id="videoDevices"></select></label>
+      <label>Microphone: <select id="audioDevices"></select></label>
+      <label>Ingest Endpoint: <input id="ingest" placeholder="a1b2c3d4e5f6.global-contribute.live-video.net" size="50" /></label>
+      <label>Stream Key: <input id="streamKey" size="50" /></label>
+    </div>
+
+    <div>
+      <video id="preview" width="640" height="360" autoplay muted playsinline></video>
+    </div>
+
+    <div>
+      <button id="start">Start Stream</button>
+      <button id="stop" disabled>Stop Stream</button>
+    </div>
+
+    <pre id="stats"></pre>
+  </div>
+
+  <script src="https://unpkg.com/amazon-ivs-web-broadcast@1.27.0/dist/amazon-ivs-web-broadcast.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate Amazon IVS Web Broadcast SDK for camera/microphone selection and start/stop controls
- display outbound network stats and gate features behind a Creator role
- document usage in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee0351788328ae7b45d4ca73d8a6