### PR TITLE
Implement watch position persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # next-video-site
+
+This is a simple example page that demonstrates saving and restoring video watch position.
+
+## Features
+
+- Saves watch position per video and user every 10 seconds.
+- Restores last position on load unless the user opts out using `?private=1` or storage is unavailable (private browsing).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Video Player</title>
+</head>
+<body>
+  <video id="player" controls width="640" data-video-id="sample-video" data-user-id="user1">
+    <source src="sample.mp4" type="video/mp4" />
+    Your browser does not support the video tag.
+  </video>
+  <script src="watch.js"></script>
+</body>
+</html>

--- a/watch.js
+++ b/watch.js
@@ -1,0 +1,48 @@
+(function () {
+  const video = document.getElementById('player');
+  if (!video) return;
+
+  const videoId = video.dataset.videoId || 'default';
+  const userId = video.dataset.userId || 'guest';
+  const storageKey = `videoProgress:${userId}:${videoId}`;
+
+  // Detect private browsing or disabled storage
+  let storageAvailable = true;
+  try {
+    localStorage.setItem('__storage_test__', '1');
+    localStorage.removeItem('__storage_test__');
+  } catch (e) {
+    storageAvailable = false;
+  }
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const optOut = urlParams.get('private') === '1';
+
+  if (!storageAvailable || optOut) {
+    console.warn('Watch position tracking disabled.');
+    return;
+  }
+
+  // Restore last position
+  const saved = localStorage.getItem(storageKey);
+  if (saved) {
+    const time = parseFloat(saved);
+    if (!isNaN(time)) {
+      video.currentTime = time;
+    }
+  }
+
+  // Save position every 10 seconds
+  const interval = 10000;
+  const saveProgress = () => {
+    if (video.paused || video.ended) return;
+    localStorage.setItem(storageKey, video.currentTime);
+  };
+  const handle = setInterval(saveProgress, interval);
+
+  // Cleanup when video ends
+  video.addEventListener('ended', () => {
+    clearInterval(handle);
+    localStorage.removeItem(storageKey);
+  });
+})();


### PR DESCRIPTION
## Summary
- save video progress per user and video every 10 seconds
- restore last watch position on load when not in private mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee06960c83288e6c50d6a841e14c