### PR TITLE
Add API Gateway usage plan and WAF configuration with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # next-video-site
+
+This repository contains a CloudFormation template that configures API Gateway with
+usage plans and API keys for server-to-server clients. A Web Application Firewall
+(WAF) with AWS managed rules and a rate-based rule protects the API.
+
+## Testing
+
+Install test requirements and run:
+
+```
+pip install -r requirements.txt
+pytest
+```

--- a/api_gateway_waf.yaml
+++ b/api_gateway_waf.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: API Gateway with usage plan, API key and WAF
+Resources:
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
+    Properties:
+      Name: NextVideoApi
+  Deployment:
+    Type: AWS::ApiGateway::Deployment
+    Properties:
+      RestApiId: !Ref RestApi
+      StageName: prod
+    DependsOn: RestApi
+  UsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    Properties:
+      UsagePlanName: ServerUsagePlan
+      ApiStages:
+        - ApiId: !Ref RestApi
+          Stage: prod
+      Throttle:
+        BurstLimit: 500
+        RateLimit: 1000
+  ServerApiKey:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Name: ServerToServerKey
+      Enabled: true
+  UsagePlanKey:
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !Ref ServerApiKey
+      KeyType: API_KEY
+      UsagePlanId: !Ref UsagePlan
+  WebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: ApiGatewayWebACL
+      Scope: REGIONAL
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: apiGatewayWebAcl
+        SampledRequestsEnabled: true
+      Rules:
+        - Name: AWSManagedRulesCommonRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: awsCommonRules
+            SampledRequestsEnabled: true
+        - Name: RateLimit
+          Priority: 2
+          Action:
+            Block: {}
+          Statement:
+            RateBasedStatement:
+              Limit: 1000
+              AggregateKeyType: IP
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: rateLimit
+            SampledRequestsEnabled: true
+  WebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      WebACLArn: !GetAtt WebACL.Arn
+      ResourceArn: !Sub arn:aws:apigateway:${AWS::Region}::/restapis/${RestApi}/stages/prod
+Outputs:
+  ApiKeyId:
+    Value: !Ref ServerApiKey

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+pytest

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,43 @@
+import yaml
+from pathlib import Path
+
+class CfnLoader(yaml.SafeLoader):
+    pass
+
+def _construct_ref(loader, node):
+    return {'Ref': loader.construct_scalar(node)}
+
+def _construct_getatt(loader, node):
+    return {'Fn::GetAtt': loader.construct_scalar(node)}
+
+def _construct_sub(loader, node):
+    return {'Fn::Sub': loader.construct_scalar(node)}
+
+CfnLoader.add_constructor('!Ref', _construct_ref)
+CfnLoader.add_constructor('!GetAtt', _construct_getatt)
+CfnLoader.add_constructor('!Sub', _construct_sub)
+
+def load_template():
+    template_path = Path(__file__).resolve().parent.parent / "api_gateway_waf.yaml"
+    with open(template_path) as f:
+        return yaml.load(f, Loader=CfnLoader)
+
+def test_usage_plan_and_api_key_present():
+    tpl = load_template()
+    resources = tpl["Resources"]
+    assert "UsagePlan" in resources
+    assert resources["UsagePlan"]["Type"] == "AWS::ApiGateway::UsagePlan"
+    assert "ServerApiKey" in resources
+    assert resources["ServerApiKey"]["Type"] == "AWS::ApiGateway::ApiKey"
+    assert "UsagePlanKey" in resources
+
+def test_waf_has_managed_and_rate_limit_rules():
+    tpl = load_template()
+    rules = tpl["Resources"]["WebACL"]["Properties"]["Rules"]
+    names = {r["Name"] for r in rules}
+    assert "AWSManagedRulesCommonRuleSet" in names
+    assert "RateLimit" in names
+    managed = next(r for r in rules if r["Name"] == "AWSManagedRulesCommonRuleSet")
+    assert managed["Statement"]["ManagedRuleGroupStatement"]["Name"] == "AWSManagedRulesCommonRuleSet"
+    rate_rule = next(r for r in rules if r["Name"] == "RateLimit")
+    assert rate_rule["Statement"]["RateBasedStatement"]["Limit"] == 1000


### PR DESCRIPTION
## Summary
- add CloudFormation template defining API Gateway usage plan with API key
- protect API with WAF using AWS managed rules and rate-based rule
- add tests verifying template contents

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee0a18b88328b62e363092220687