### PR TITLE
Add Redis cache wrapper and Terraform config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # next-video-site
+
+## Provisioning Redis with Terraform
+
+The `infra/redis.tf` configuration provisions an Amazon ElastiCache Redis cluster.
+
+1. Ensure you have Terraform and AWS credentials configured.
+2. Provide `region` and a list of `subnet_ids` when applying:
+
+```bash
+terraform -chdir=infra init
+terraform -chdir=infra apply -var 'region=us-east-1' -var 'subnet_ids=["subnet-123","subnet-456"]'
+```
+
+## Cache Wrapper
+
+`src/cache.ts` exposes a simple cache-aside wrapper around Redis using a TTL and health checks.
+
+Example usage:
+
+```ts
+import { RedisCache } from "./src/cache";
+
+const cache = new RedisCache(process.env.REDIS_URL!, { ttlSeconds: 60 });
+const value = await cache.get("key", async () => "fresh" );
+const healthy = await cache.isHealthy();
+```

--- a/infra/redis.tf
+++ b/infra/redis.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_elasticache_subnet_group" "default" {
+  name       = "video-site-cache-subnets"
+  subnet_ids = var.subnet_ids
+}
+
+resource "aws_elasticache_cluster" "default" {
+  cluster_id           = "video-site-cache"
+  engine               = "redis"
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  subnet_group_name    = aws_elasticache_subnet_group.default.name
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for Redis subnet group"
+  type        = list(string)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,142 @@
+{
+  "name": "next-video-site",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "next-video-site",
+      "version": "1.0.0",
+      "dependencies": {
+        "ioredis": "^5.3.2"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.0"
+      }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "next-video-site",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "test": "npm run build"
+  },
+  "dependencies": {
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,50 @@
+import Redis, { Redis as RedisClient } from "ioredis";
+
+export interface CacheOptions {
+  /** Time to live for cached entries in seconds */
+  ttlSeconds: number;
+}
+
+export class RedisCache {
+  private client: RedisClient;
+  private ttlSeconds: number;
+
+  constructor(redisUrl: string, options: CacheOptions) {
+    this.client = new Redis(redisUrl);
+    this.ttlSeconds = options.ttlSeconds;
+  }
+
+  /**
+   * Retrieve a value from cache or fallback to a fetcher.
+   * Implements the cache-aside pattern.
+   */
+  async get<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+    const cached = await this.client.get(key);
+    if (cached) {
+      return JSON.parse(cached) as T;
+    }
+    const value = await fetcher();
+    await this.client.set(key, JSON.stringify(value), "EX", this.ttlSeconds);
+    return value;
+  }
+
+  /** Store a value in cache with the configured TTL */
+  async set<T>(key: string, value: T): Promise<void> {
+    await this.client.set(key, JSON.stringify(value), "EX", this.ttlSeconds);
+  }
+
+  /** Simple health check using Redis PING */
+  async isHealthy(): Promise<boolean> {
+    try {
+      await this.client.ping();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Close the underlying Redis connection */
+  async disconnect(): Promise<void> {
+    await this.client.quit();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- provision ElastiCache Redis cluster with Terraform example
- add TypeScript Redis cache wrapper using cache-aside pattern with TTL and health checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee12b47c8328aa657ae47c32b68a