### PR TITLE
Add Terraform VPC with subnets, NAT gateways, and endpoints

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.9.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:wDPMwwO3cFi8sYelHxBc+DyWff3ywAcpJ1nIJbQQFao=",
+    "zh:0121aeca90856ba37d03cff9eed40321cc3ae1c0f77bef3329e17212c48f884a",
+    "zh:4f09e73f948d4545358eed978bc41fd1a825c65b530a532bfaf9aaba93ac6e55",
+    "zh:58604213402b5dba8360367e09b3d3762736980c80a72d6297be7cb71fe8dc8d",
+    "zh:5aa9fe54fc9aba0780cae11becfce698e5093ee002066590599277d5aa71e59e",
+    "zh:7e8546575a80d54b8db7edb53574c2d1f04afbdbafc599d0eb78da9e74e917f7",
+    "zh:846ce59c9f7ec3c92b33fe3a0d98386420bcbb971260da9ff869b219a1125df4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9bd2cb527dcbd76977c18f3f6844638b6d5039f070accc41d064831f98aa7b40",
+    "zh:9df98266de85cf047c9a2e43b892c74479805e0936dbb3583aef314d2fa0f5fc",
+    "zh:a4fc8e9645b147902bcf36f10ea1891ca92661c4ee4135046cc79b8ce6fe1093",
+    "zh:afe3029760f7aa5484e26c80670f86b6b5054126776376ba6aec4aa8a41483ce",
+    "zh:c158cd1790422237ab2a2e10fc02e5522bd7bce39c067ffbc9edda1e6c9ebf3b",
+    "zh:f5408929d5df6f81fcb93a433e0dbc0432b748b400cc41910328b936a7590fd5",
+    "zh:f6331bb27134e288d8c324b2390c610fd924f71af1ec27f79070dfa26f4dd410",
+    "zh:f6b8b429d5fa71f186bda45468bbde230a1697a38480487f41d7172f1e374e2d",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,206 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  azs = slice(data.aws_availability_zones.available.names, 0, 3)
+}
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "${var.project}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "${var.project}-igw"
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each                = { for idx, az in local.azs : az => idx }
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, each.value)
+  availability_zone       = each.key
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "${var.project}-public-${each.key}"
+  }
+}
+
+resource "aws_subnet" "private_stage" {
+  for_each                = { for idx, az in local.azs : az => idx }
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, each.value + 3)
+  availability_zone       = each.key
+  map_public_ip_on_launch = false
+  tags = {
+    Name = "${var.project}-stage-${each.key}"
+  }
+}
+
+resource "aws_subnet" "private_prod" {
+  for_each                = { for idx, az in local.azs : az => idx }
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 4, each.value + 6)
+  availability_zone       = each.key
+  map_public_ip_on_launch = false
+  tags = {
+    Name = "${var.project}-prod-${each.key}"
+  }
+}
+
+resource "aws_eip" "nat_stage" {
+  domain = "vpc"
+  tags = {
+    Name = "${var.project}-nat-stage-eip"
+  }
+}
+
+resource "aws_eip" "nat_prod" {
+  domain = "vpc"
+  tags = {
+    Name = "${var.project}-nat-prod-eip"
+  }
+}
+
+resource "aws_nat_gateway" "stage" {
+  allocation_id = aws_eip.nat_stage.id
+  subnet_id     = aws_subnet.public[local.azs[0]].id
+  tags = {
+    Name = "${var.project}-nat-stage"
+  }
+  depends_on = [aws_internet_gateway.igw]
+}
+
+resource "aws_nat_gateway" "prod" {
+  allocation_id = aws_eip.nat_prod.id
+  subnet_id     = aws_subnet.public[local.azs[0]].id
+  tags = {
+    Name = "${var.project}-nat-prod"
+  }
+  depends_on = [aws_internet_gateway.igw]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+  tags = {
+    Name = "${var.project}-public-rt"
+  }
+}
+
+resource "aws_route_table" "stage" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.stage.id
+  }
+  tags = {
+    Name = "${var.project}-stage-rt"
+  }
+}
+
+resource "aws_route_table" "prod" {
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.prod.id
+  }
+  tags = {
+    Name = "${var.project}-prod-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  for_each       = aws_subnet.public
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "stage" {
+  for_each       = aws_subnet.private_stage
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.stage.id
+}
+
+resource "aws_route_table_association" "prod" {
+  for_each       = aws_subnet.private_prod
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.prod.id
+}
+
+resource "aws_security_group" "stage" {
+  name        = "${var.project}-stage-sg"
+  description = "Stage default security group"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-stage-sg"
+  }
+}
+
+resource "aws_security_group" "prod" {
+  name        = "${var.project}-prod-sg"
+  description = "Prod default security group"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project}-prod-sg"
+  }
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.stage.id, aws_route_table.prod.id]
+  tags = {
+    Name = "${var.project}-s3-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.stage.id, aws_route_table.prod.id]
+  tags = {
+    Name = "${var.project}-dynamodb-endpoint"
+  }
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,24 @@
+output "public_subnet_ids" {
+  description = "IDs of public subnets"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "stage_private_subnet_ids" {
+  description = "IDs of stage private subnets"
+  value       = [for s in aws_subnet.private_stage : s.id]
+}
+
+output "prod_private_subnet_ids" {
+  description = "IDs of prod private subnets"
+  value       = [for s in aws_subnet.private_prod : s.id]
+}
+
+output "stage_security_group_id" {
+  description = "Stage security group ID"
+  value       = aws_security_group.stage.id
+}
+
+output "prod_security_group_id" {
+  description = "Prod security group ID"
+  value       = aws_security_group.prod.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "project" {
+  description = "Project name prefix"
+  type        = string
+  default     = "next-video-site"
+}


### PR DESCRIPTION
## Summary
- define VPC across three AZs with public and stage/prod private subnets
- provision NAT gateways, route tables, and gateway endpoints for S3 and DynamoDB
- export subnet and security group IDs for easy use

## Testing
- `terraform fmt -recursive -check`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee143cdc8328a89a133dc16aa727