### PR TITLE
feat: add cloudfront distribution template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # next-video-site
+
+Infrastructure templates for deploying a CloudFront distribution with:
+- Application Load Balancer origin for server‑side rendering.
+- S3 origin for static assets and video on demand.
+- Cache policies tuned for dynamic and static content.
+- Origin access control for securing the S3 bucket.
+- Origin group failover from the ALB to S3.
+- WAFv2 Web ACL integration.
+
+The template is located at `infra/cloudfront-distribution.yaml` and can be
+validated locally with [cfn-lint](https://github.com/aws-cloudformation/cfn-lint):
+
+```bash
+cfn-lint infra/cloudfront-distribution.yaml
+```

--- a/infra/cloudfront-distribution.yaml
+++ b/infra/cloudfront-distribution.yaml
@@ -1,0 +1,160 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFront distribution with ALB and S3 origins, OAC, cache policies, failover, and WAF
+
+Parameters:
+  AlbDomainName:
+    Type: String
+    Description: DNS name of the Application Load Balancer serving SSR content
+  S3BucketName:
+    Type: String
+    Description: Name of the S3 bucket hosting static/VOD assets
+
+Resources:
+  S3OriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub '${AWS::StackName}-s3-oac'
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  StaticBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref S3BucketName
+
+  StaticBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref StaticBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: 's3:GetObject'
+            Resource: !Sub '${StaticBucket.Arn}/*'
+            Condition:
+              StringEquals:
+                'AWS:SourceArn': !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}'
+
+  SSRCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: SSRCachePolicy
+        DefaultTTL: 0
+        MaxTTL: 0
+        MinTTL: 0
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: all
+          HeadersConfig:
+            HeaderBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: all
+          EnableAcceptEncodingGzip: true
+          EnableAcceptEncodingBrotli: true
+
+  StaticCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: StaticCachePolicy
+        DefaultTTL: 86400
+        MaxTTL: 31536000
+        MinTTL: 0
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: none
+          HeadersConfig:
+            HeaderBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+          EnableAcceptEncodingGzip: true
+          EnableAcceptEncodingBrotli: true
+
+  WebAcl:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: cloudfront-web-acl
+      Scope: CLOUDFRONT
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: cfWebAcl
+      Rules:
+        - Name: AWS-AWSManagedRulesCommonRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: commonRules
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultRootObject: index.html
+        WebACLId: !GetAtt WebAcl.Arn
+        Origins:
+          - Id: AlbOrigin
+            DomainName: !Ref AlbDomainName
+            CustomOriginConfig:
+              OriginProtocolPolicy: https-only
+              OriginSSLProtocols:
+                - TLSv1.2
+          - Id: S3Origin
+            DomainName: !GetAtt StaticBucket.DomainName
+            S3OriginConfig: {}
+            OriginAccessControlId: !Ref S3OriginAccessControl
+        OriginGroups:
+          Quantity: 1
+          Items:
+            - Id: SSRFailoverGroup
+              FailoverCriteria:
+                StatusCodes:
+                  Items: [500, 502, 503, 504]
+                  Quantity: 4
+              Members:
+                Quantity: 2
+                Items:
+                  - OriginId: AlbOrigin
+                  - OriginId: S3Origin
+        DefaultCacheBehavior:
+          TargetOriginId: SSRFailoverGroup
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE]
+          CachedMethods: [GET, HEAD]
+          CachePolicyId: !Ref SSRCachePolicy
+        CacheBehaviors:
+          - PathPattern: 'static/*'
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods: [GET, HEAD, OPTIONS]
+            CachedMethods: [GET, HEAD]
+            CachePolicyId: !Ref StaticCachePolicy
+          - PathPattern: 'videos/*'
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            AllowedMethods: [GET, HEAD, OPTIONS]
+            CachedMethods: [GET, HEAD]
+            CachePolicyId: !Ref StaticCachePolicy
+        ViewerCertificate:
+          CloudFrontDefaultCertificate: true
+
+Outputs:
+  DistributionId:
+    Description: ID of the CloudFront distribution
+    Value: !Ref CloudFrontDistribution


### PR DESCRIPTION
## Summary
- add CloudFormation template for CloudFront with ALB and S3 origins
- include cache policies, origin access control, failover group, and WAF
- document infrastructure and validation command

## Testing
- `cfn-lint infra/cloudfront-distribution.yaml && echo 'cfn-lint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee15b2188328bd32ee70568163e1