### PR TITLE
Add permission boundary and IAM policy validation

### DIFF
--- a/.github/workflows/iam-policy-check.yml
+++ b/.github/workflows/iam-policy-check.yml
@@ -1,0 +1,24 @@
+name: IAM Policy Check
+
+on:
+  pull_request:
+    paths:
+      - 'policies/**'
+      - 'scripts/validate_iam_policies.sh'
+  push:
+    branches: [ main ]
+    paths:
+      - 'policies/**'
+      - 'scripts/validate_iam_policies.sh'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install AWS CLI
+        run: sudo apt-get update && sudo apt-get install -y awscli jq
+      - name: Validate policies
+        run: ./scripts/validate_iam_policies.sh origin/main HEAD

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # next-video-site
+
+This repository contains IAM policy examples and validation tooling.
+
+## Policies
+- `policies/permission-boundary.json` defines a sample permission boundary limiting privileges.
+
+## Validation
+The script `scripts/validate_iam_policies.sh` uses AWS IAM Access Analyzer to validate policy JSON files and blocks wildcard actions or resources. GitHub Actions runs this script on policy changes.
+
+Run locally:
+
+```bash
+./scripts/validate_iam_policies.sh
+```

--- a/policies/permission-boundary.json
+++ b/policies/permission-boundary.json
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowS3BucketObjects",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::example-bucket/*"
+    },
+    {
+      "Sid": "AllowS3List",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::example-bucket"
+    },
+    {
+      "Sid": "AllowLogWrite",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:us-east-1:123456789012:log-group:example:*"
+    },
+    {
+      "Sid": "DenyIAM",
+      "Effect": "Deny",
+      "Action": "iam:*",
+      "Resource": "arn:aws:iam::*"
+    },
+    {
+      "Sid": "DenyEC2",
+      "Effect": "Deny",
+      "Action": "ec2:*",
+      "Resource": "arn:aws:ec2:*:*:*"
+    }
+  ]
+}

--- a/scripts/validate_iam_policies.sh
+++ b/scripts/validate_iam_policies.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE=${1:-origin/main}
+HEAD=${2:-HEAD}
+
+CHANGED=$(git diff --name-only "$BASE" "$HEAD" -- 'policies/*.json')
+if [ -z "$CHANGED" ]; then
+  echo "No policy changes detected."
+  exit 0
+fi
+
+status=0
+for file in $CHANGED; do
+  echo "Validating $file"
+  if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    aws accessanalyzer validate-policy \
+      --region us-east-1 \
+      --policy-document file://"$file" \
+      --policy-type IDENTITY_POLICY > /tmp/va.json
+
+    if jq -e '.findings[] | select(.findingType=="ERROR")' /tmp/va.json >/dev/null; then
+      echo "Access Analyzer found errors in $file"
+      jq '.findings' /tmp/va.json
+      status=1
+    fi
+
+    rm /tmp/va.json
+  else
+    echo "Skipping Access Analyzer validation for $file; AWS credentials not configured." >&2
+  fi
+
+  if git diff "$BASE" "$HEAD" -- "$file" | grep -E '^\+.*"Action"\s*:\s*"\*"'; then
+    echo "Wildcard action detected in $file"
+    status=1
+  fi
+  if git diff "$BASE" "$HEAD" -- "$file" | grep -E '^\+.*"Resource"\s*:\s*"\*"'; then
+    echo "Wildcard resource detected in $file"
+    status=1
+  fi
+
+done
+exit $status


### PR DESCRIPTION
## Summary
- define sample IAM permission boundary policy
- add script invoking IAM Access Analyzer and checking for wildcard actions/resources
- run policy validation in GitHub Actions

## Testing
- `./scripts/validate_iam_policies.sh main HEAD` *(fails: skipping Access Analyzer; AWS credentials not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee191590832899cde74085bc1662