### PR TITLE
Add WAF template with managed rules and GraphQL introspection alarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # next-video-site
+
+This repository contains infrastructure configuration for the Next Video Site. 
+
+## WAF
+
+The CloudFormation template in [`cloudformation/waf.yaml`](cloudformation/waf.yaml) attaches AWS managed rule groups, includes a placeholder rule to block GraphQL introspection attempts, and publishes CloudWatch metrics and an alarm for blocked requests.
+
+Deploy with:
+
+```bash
+aws cloudformation deploy --template-file cloudformation/waf.yaml --stack-name NextVideoSiteWAF --capabilities CAPABILITY_NAMED_IAM
+```

--- a/cloudformation/waf.yaml
+++ b/cloudformation/waf.yaml
@@ -1,0 +1,91 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: WAF configuration for Next Video Site with AWS managed rule groups and GraphQL introspection blocking.
+
+Resources:
+  GraphQLIntrospectionPattern:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      Name: GraphQLIntrospectionPattern
+      Scope: CLOUDFRONT
+      RegularExpressionList:
+        - "__schema"
+        - "__type"
+
+  WebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Name: NextVideoSiteWebACL
+      Scope: CLOUDFRONT
+      DefaultAction:
+        Allow: {}
+      VisibilityConfig:
+        CloudWatchMetricsEnabled: true
+        MetricName: NextVideoSiteWebACL
+        SampledRequestsEnabled: true
+      Rules:
+        - Name: AWSManagedRulesCommonRuleSet
+          Priority: 1
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesCommonRuleSet
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedCommonRules
+            SampledRequestsEnabled: true
+        - Name: AWSManagedRulesKnownBadInputsRuleSet
+          Priority: 2
+          OverrideAction:
+            None: {}
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesKnownBadInputsRuleSet
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: AWSManagedBadInputsRules
+            SampledRequestsEnabled: true
+        - Name: BlockGraphQLIntrospection
+          Priority: 10
+          Action:
+            Block: {}
+          Statement:
+            RegexPatternSetReferenceStatement:
+              Arn: !GetAtt GraphQLIntrospectionPattern.Arn
+              FieldToMatch:
+                Body: {}
+              TextTransformations:
+                - Priority: 0
+                  Type: LOWERCASE
+          VisibilityConfig:
+            CloudWatchMetricsEnabled: true
+            MetricName: BlockGraphQLIntrospection
+            SampledRequestsEnabled: true
+
+  GraphQLIntrospectionAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: GraphQLIntrospectionBlocks
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      Threshold: 0
+      Metrics:
+        - Id: m1
+          MetricStat:
+            Metric:
+              Namespace: AWS/WAFV2
+              MetricName: BlockedRequests
+              Dimensions:
+                - Name: WebACL
+                  Value: !Ref WebACL
+                - Name: Region
+                  Value: Global
+                - Name: Rule
+                  Value: BlockGraphQLIntrospection
+            Period: 300
+            Stat: Sum
+          ReturnData: true
+      TreatMissingData: notBreaching
+      AlarmDescription: Alarm when GraphQL introspection requests are blocked.


### PR DESCRIPTION
## Summary
- add CloudFormation template that attaches AWS managed rule groups and custom rule blocking GraphQL introspection
- expose CloudWatch metrics and alarm for blocked introspection
- document new infrastructure template in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee1ab37c83288a3d743c4b123441