### PR TITLE
Add DR infrastructure and failover tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Terraform state
+**/.terraform/*
+*.tfstate
+*.tfstate.*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# next-video-site
+# Next Video Site
+
+This repository contains infrastructure and scripts for the application.
+
+- [`infrastructure/`](infrastructure/) — Terraform configuration enabling RDS backups, DynamoDB point-in-time recovery, and S3 cross-region replication.
+- [`docs/disaster-recovery.md`](docs/disaster-recovery.md) — disaster recovery procedures.
+- [`scripts/failover.sh`](scripts/failover.sh) — one-button failover script.

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,19 @@
+# Disaster Recovery Plan
+
+This project enables automated backups and replication for critical services.
+
+## RDS
+- Automated backups retained for seven days (`backup_retention_period = 7`).
+- Snapshots are tagged and can be restored in the primary or DR region.
+
+## DynamoDB
+- Point-in-time recovery is enabled allowing restoration to any second in the last 35 days.
+
+## S3 Assets
+- Object versioning is enabled and the bucket replicates to a bucket in the DR region via cross‑region replication.
+
+## Failover Procedure
+1. Ensure the DR infrastructure is healthy.
+2. Run [`scripts/failover.sh`](../scripts/failover.sh) to promote the DR database and update DNS records.
+3. Verify application health in the DR region.
+4. After the primary region is restored, reverse the replication and switch DNS back.

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,0 +1,115 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.primary_region
+}
+
+provider "aws" {
+  alias  = "dr"
+  region = var.dr_region
+}
+
+# RDS instance with automated backups
+resource "aws_db_instance" "app" {
+  identifier              = var.db_identifier
+  engine                  = "postgres"
+  instance_class          = "db.t3.micro"
+  allocated_storage       = 20
+  username                = var.db_username
+  password                = var.db_password
+  skip_final_snapshot     = false
+  backup_retention_period = 7
+  backup_window           = "03:00-04:00"
+  copy_tags_to_snapshot   = true
+}
+
+# DynamoDB table with point-in-time recovery
+resource "aws_dynamodb_table" "app" {
+  name         = var.ddb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+}
+
+# S3 buckets with cross-region replication
+resource "aws_s3_bucket" "assets" {
+  bucket = var.assets_bucket
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket" "assets_dr" {
+  provider = aws.dr
+  bucket   = "${var.assets_bucket}-dr"
+  versioning {
+    enabled = true
+  }
+}
+
+data "aws_iam_policy_document" "replication_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  name               = "${var.assets_bucket}-replication-role"
+  assume_role_policy = data.aws_iam_policy_document.replication_assume.json
+}
+
+data "aws_iam_policy_document" "replication" {
+  statement {
+    actions   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
+    resources = [aws_s3_bucket.assets.arn]
+  }
+
+  statement {
+    actions   = ["s3:GetObjectVersion", "s3:GetObjectVersionAcl", "s3:GetObjectVersionForReplication", "s3:GetObjectVersionTagging"]
+    resources = ["${aws_s3_bucket.assets.arn}/*"]
+  }
+
+  statement {
+    actions   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags", "s3:GetObjectVersionTagging", "s3:List*"]
+    resources = ["${aws_s3_bucket.assets_dr.arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "replication" {
+  role   = aws_iam_role.replication.id
+  policy = data.aws_iam_policy_document.replication.json
+}
+
+resource "aws_s3_bucket_replication_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  role   = aws_iam_role.replication.arn
+
+  rule {
+    id     = "dr"
+    status = "Enabled"
+    filter {}
+    destination {
+      bucket        = aws_s3_bucket.assets_dr.arn
+      storage_class = "STANDARD"
+    }
+  }
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,37 @@
+variable "primary_region" {
+  description = "Primary AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "dr_region" {
+  description = "Disaster recovery region"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "db_identifier" {
+  description = "Identifier for the RDS instance"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Master username for RDS"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Master password for RDS"
+  type        = string
+  sensitive   = true
+}
+
+variable "ddb_table_name" {
+  description = "Name of the DynamoDB table"
+  type        = string
+}
+
+variable "assets_bucket" {
+  description = "Name of the primary S3 bucket for assets"
+  type        = string
+}

--- a/scripts/failover.sh
+++ b/scripts/failover.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# One-button failover script
+# Requires AWS CLI and credentials configured.
+set -euo pipefail
+
+PRIMARY_REGION=${PRIMARY_REGION:-us-east-1}
+DR_REGION=${DR_REGION:-us-west-2}
+DB_IDENTIFIER=${DB_IDENTIFIER:-myapp-db}
+HOSTED_ZONE_ID=${HOSTED_ZONE_ID:-Z123456789}
+RECORD_NAME=${RECORD_NAME:-app.example.com}
+DR_ELB_NAME=${DR_ELB_NAME:-myapp-dr}
+
+printf 'Promoting RDS read replica in %s\n' "$DR_REGION"
+aws rds promote-read-replica \
+  --db-instance-identifier "${DB_IDENTIFIER}-dr" \
+  --region "$DR_REGION"
+
+printf 'Updating DNS record %s to DR region\n' "$RECORD_NAME"
+ELB_ZONE=$(aws elbv2 describe-load-balancers --names "$DR_ELB_NAME" --region "$DR_REGION" --query 'LoadBalancers[0].CanonicalHostedZoneId' --output text)
+ELB_DNS=$(aws elbv2 describe-load-balancers --names "$DR_ELB_NAME" --region "$DR_REGION" --query 'LoadBalancers[0].DNSName' --output text)
+
+aws route53 change-resource-record-sets \
+  --hosted-zone-id "$HOSTED_ZONE_ID" \
+  --change-batch "{\"Changes\":[{\"Action\":\"UPSERT\",\"ResourceRecordSet\":{\"Name\":\"$RECORD_NAME\",\"Type\":\"A\",\"AliasTarget\":{\"HostedZoneId\":\"$ELB_ZONE\",\"DNSName\":\"$ELB_DNS\",\"EvaluateTargetHealth\":false}}}]}"
+
+printf 'Failover complete.\n'


### PR DESCRIPTION
## Summary
- add Terraform config enabling RDS backups, DynamoDB PITR, and S3 cross-region replication
- document disaster recovery process
- provide one-button failover script

## Testing
- `terraform validate`
- `shellcheck scripts/failover.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee2022c88328ba150176ebcf9817