### PR TITLE
Add recommendations API endpoint

### DIFF
--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -1,1 +1,22 @@
-﻿// File cleared by force push to main
+export default function handler(req, res) {
+  res.status(200).json([
+    {
+      id: 1,
+      title: 'Understanding Async/Await',
+      thumbnail: '/thumbnails/async-await.png',
+      url: 'https://example.com/videos/1'
+    },
+    {
+      id: 2,
+      title: 'JavaScript Promises in Depth',
+      thumbnail: '/thumbnails/promises.png',
+      url: 'https://example.com/videos/2'
+    },
+    {
+      id: 3,
+      title: 'React Hooks Crash Course',
+      thumbnail: '/thumbnails/hooks.png',
+      url: 'https://example.com/videos/3'
+    }
+  ]);
+}


### PR DESCRIPTION
## Summary
- add default Next.js API handler for `/api/recommendations`
- return sample video recommendations as JSON

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a587f9924c8328b3d4b364d8374b4b