### PR TITLE
Block web crawlers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,18 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex, nofollow',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+export default nextConfig;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary
- Add robots.txt to disallow all agents from crawling
- Add X-Robots-Tag header via headers() in Next.js config

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7b16ea9688328b855f36f64a592a3