### PR TITLE
Add strict CSP and security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,44 @@
+const contentSecurityPolicy = `
+  default-src 'self';
+  connect-src 'self' https://*.r2.cloudflarestorage.com https://*.amazonaws.com https://*.vercel.app https://vercel.live;
+`;
+
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value: contentSecurityPolicy.replace(/\n/g, ''),
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'DENY',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+];
+
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- enforce Content Security Policy to limit connections to S3/R2 endpoints and Vercel
- apply additional HTTP headers for stricter security

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b16d5d08832883ab182b199f2737