### PR TITLE
feat: add dynamic hls.js video player

### DIFF
--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+export default function VideoPlayer({ src, ...props }) {
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    if (!videoRef.current || !src) return;
+    if (!src.includes('.m3u8')) {
+      // For non-HLS sources just set src normally
+      videoRef.current.src = src;
+      return;
+    }
+
+    let hls;
+    async function initPlayer() {
+      // Check for native HLS support first
+      if (videoRef.current.canPlayType('application/vnd.apple.mpegurl')) {
+        videoRef.current.src = src;
+        return;
+      }
+      // Dynamically import hls.js for browsers that need it
+      const { default: Hls } = await import('hls.js');
+      if (Hls.isSupported()) {
+        hls = new Hls();
+        hls.loadSource(src);
+        hls.attachMedia(videoRef.current);
+      }
+    }
+
+    initPlayer();
+
+    return () => {
+      if (hls) {
+        hls.destroy();
+      }
+    };
+  }, [src]);
+
+  return <video ref={videoRef} controls {...props} />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "next-video-site",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-personalize": "^3.556.0"
+        "@aws-sdk/client-personalize": "^3.556.0",
+        "hls.js": "^1.6.11"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1233,6 +1234,12 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.11.tgz",
+      "integrity": "sha512-tdDwOAgPGXohSiNE4oxGr3CI9Hx9lsGLFe6TULUvRk2TfHS+w1tSAJntrvxsHaxvjtr6BXsDZM7NOqJFhU4mmg==",
+      "license": "Apache-2.0"
     },
     "node_modules/strnum": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@aws-sdk/client-personalize": "^3.556.0"
+    "@aws-sdk/client-personalize": "^3.556.0",
+    "hls.js": "^1.6.11"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import VideoPlayer from '../components/VideoPlayer';
 
 export default function Home() {
   const [videos, setVideos] = useState([]);
@@ -21,7 +22,7 @@ export default function Home() {
   return (
     <div className="container">
       <h1>Recommended Videos</h1>
-      <div className="video-player">Video player coming soon...</div>
+      <VideoPlayer src={videos[0]?.url} className="video-player" />
       <ul className="video-list">
         {Array.isArray(videos) && videos.map((video, idx) => (
           <li key={idx}>


### PR DESCRIPTION
## Summary
- dynamically import hls.js and attach to video element when supported
- wire up homepage to use new VideoPlayer component
- add hls.js dependency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b1695ff083288f29d5eb19c43e4e