### PR TITLE
Add basic auth middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+
+const USER = process.env.BASIC_AUTH_USER;
+const PASS = process.env.BASIC_AUTH_PASS;
+
+export function middleware(request) {
+  if (USER && PASS) {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader) {
+      const [scheme, encoded] = authHeader.split(' ');
+      if (scheme === 'Basic') {
+        const decoded = atob(encoded);
+        const [user, pass] = decoded.split(':');
+        if (user === USER && pass === PASS) {
+          return NextResponse.next();
+        }
+      }
+    }
+    return new Response('Authentication required', {
+      status: 401,
+      headers: {
+        'WWW-Authenticate': 'Basic realm="Secure Area"',
+      },
+    });
+  }
+  return NextResponse.next();
+}


### PR DESCRIPTION
## Summary
- add middleware that reads BASIC_AUTH_USER and BASIC_AUTH_PASS env vars
- enforce HTTP basic authentication for all requests

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7b16bedb08328a1fe2cc7162602fb