### PR TITLE
Add clip metadata display and share link generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 ## Overview
 This repository contains a Next.js example app that serves video content and demonstrates how to integrate Amazon Personalize for tailored recommendations.
 
+## Features
+- Display recommended videos and view metadata for the selected clip.
+- Generate a server-signed share link for any video.
+
 ## Prerequisites
 - Node.js 18+
 - npm

--- a/data/videos.js
+++ b/data/videos.js
@@ -1,0 +1,20 @@
+export const videos = [
+  {
+    id: 1,
+    title: 'Understanding Async/Await',
+    thumbnail: '/thumbnails/async-await.png',
+    url: 'https://example.com/videos/1'
+  },
+  {
+    id: 2,
+    title: 'JavaScript Promises in Depth',
+    thumbnail: '/thumbnails/promises.png',
+    url: 'https://example.com/videos/2'
+  },
+  {
+    id: 3,
+    title: 'React Hooks Crash Course',
+    thumbnail: '/thumbnails/hooks.png',
+    url: 'https://example.com/videos/3'
+  }
+];

--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -1,22 +1,5 @@
+import { videos } from '../../data/videos.js';
+
 export default function handler(req, res) {
-  res.status(200).json([
-    {
-      id: 1,
-      title: 'Understanding Async/Await',
-      thumbnail: '/thumbnails/async-await.png',
-      url: 'https://example.com/videos/1'
-    },
-    {
-      id: 2,
-      title: 'JavaScript Promises in Depth',
-      thumbnail: '/thumbnails/promises.png',
-      url: 'https://example.com/videos/2'
-    },
-    {
-      id: 3,
-      title: 'React Hooks Crash Course',
-      thumbnail: '/thumbnails/hooks.png',
-      url: 'https://example.com/videos/3'
-    }
-  ]);
+  res.status(200).json(videos);
 }

--- a/pages/api/share.js
+++ b/pages/api/share.js
@@ -1,0 +1,22 @@
+import crypto from 'crypto';
+import { videos } from '../../data/videos.js';
+
+const secret = process.env.SHARE_LINK_SECRET || 'mysecret';
+
+export default function handler(req, res) {
+  const { id } = req.query;
+  const video = videos.find(v => String(v.id) === String(id));
+
+  if (!video) {
+    res.status(404).json({ error: 'Video not found' });
+    return;
+  }
+
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(video.url)
+    .digest('hex');
+
+  const link = `${video.url}?sig=${signature}`;
+  res.status(200).json({ link });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 export default function Home() {
   const [videos, setVideos] = useState([]);
+  const [selectedVideo, setSelectedVideo] = useState(null);
+  const [shareLink, setShareLink] = useState('');
 
   useEffect(() => {
     async function fetchVideos() {
@@ -18,16 +20,52 @@ export default function Home() {
     fetchVideos();
   }, []);
 
+  async function handleShare() {
+    if (!selectedVideo) return;
+    try {
+      const res = await fetch(`/api/share?id=${selectedVideo.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setShareLink(data.link);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
   return (
     <div className="container">
       <h1>Recommended Videos</h1>
       <div className="video-player">Video player coming soon...</div>
+      {selectedVideo && (
+        <div className="video-meta">
+          <h2>{selectedVideo.title}</h2>
+          <img
+            src={selectedVideo.thumbnail}
+            alt={`${selectedVideo.title} thumbnail`}
+          />
+          <p>ID: {selectedVideo.id}</p>
+          <button onClick={handleShare}>Generate Share Link</button>
+          {shareLink && (
+            <p>
+              <a href={shareLink}>{shareLink}</a>
+            </p>
+          )}
+        </div>
+      )}
       <ul className="video-list">
-        {Array.isArray(videos) && videos.map((video, idx) => (
-          <li key={idx}>
-            {typeof video === 'string' ? video : video.title}
-          </li>
-        ))}
+        {Array.isArray(videos) &&
+          videos.map((video, idx) => (
+            <li
+              key={idx}
+              onClick={() => {
+                setSelectedVideo(video);
+                setShareLink('');
+              }}
+            >
+              {typeof video === 'string' ? video : video.title}
+            </li>
+          ))}
       </ul>
       <style jsx>{`
         .container {
@@ -53,9 +91,16 @@ export default function Home() {
         .video-list li {
           padding: 0.5rem 0;
           border-bottom: 1px solid #ddd;
+          cursor: pointer;
+        }
+        .video-meta {
+          margin: 1rem 0;
+        }
+        .video-meta img {
+          max-width: 100%;
+          height: auto;
         }
       `}</style>
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- show metadata for a selected video clip
- create API to generate server-signed share links
- centralize video data for reuse

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b167d0a48328b6ab91638abd3b33