### PR TITLE
Render clip grid with no-store fetch

### DIFF
--- a/pages/api/clips.js
+++ b/pages/api/clips.js
@@ -1,0 +1,19 @@
+export default function handler(req, res) {
+  res.status(200).json([
+    {
+      id: 1,
+      poster: 'https://via.placeholder.com/320x180?text=Clip+1',
+      src: 'https://www.w3schools.com/html/mov_bbb.mp4'
+    },
+    {
+      id: 2,
+      poster: 'https://via.placeholder.com/320x180?text=Clip+2',
+      src: 'https://www.w3schools.com/html/movie.mp4'
+    },
+    {
+      id: 3,
+      poster: 'https://via.placeholder.com/320x180?text=Clip+3',
+      src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4'
+    }
+  ]);
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,58 +1,54 @@
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const [videos, setVideos] = useState([]);
+  const [clips, setClips] = useState([]);
 
   useEffect(() => {
-    async function fetchVideos() {
+    async function fetchClips() {
       try {
-        const res = await fetch('/api/recommendations');
+        const res = await fetch('/api/clips', { cache: 'no-store' });
         if (res.ok) {
           const data = await res.json();
-          setVideos(data);
+          setClips(data);
         }
       } catch (err) {
         console.error(err);
       }
     }
-    fetchVideos();
+    fetchClips();
   }, []);
 
   return (
     <div className="container">
-      <h1>Recommended Videos</h1>
-      <div className="video-player">Video player coming soon...</div>
-      <ul className="video-list">
-        {Array.isArray(videos) && videos.map((video, idx) => (
-          <li key={idx}>
-            {typeof video === 'string' ? video : video.title}
-          </li>
-        ))}
-      </ul>
+      <h1>Clips</h1>
+      <div className="clip-grid">
+        {Array.isArray(clips) &&
+          clips.map((clip) => (
+            <div key={clip.id} className="clip-item">
+              <video
+                controls
+                poster={clip.poster}
+                src={clip.src}
+              />
+            </div>
+          ))}
+      </div>
       <style jsx>{`
         .container {
-          max-width: 800px;
+          max-width: 1200px;
           margin: 0 auto;
           padding: 2rem;
           font-family: sans-serif;
         }
-        .video-player {
+        .clip-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+          gap: 1rem;
+        }
+        .clip-item video {
           width: 100%;
-          height: 360px;
-          background: #000;
-          color: #fff;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          margin-bottom: 1rem;
-        }
-        .video-list {
-          list-style: none;
-          padding: 0;
-        }
-        .video-list li {
-          padding: 0.5rem 0;
-          border-bottom: 1px solid #ddd;
+          height: auto;
+          display: block;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- Fetch `/api/clips` with `cache: "no-store"` in the home page.
- Display clips as a responsive grid of videos using poster images.
- Add `/api/clips` endpoint returning sample clip data.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b16604648328938209163242b5e0