### PR TITLE
Delete stale uploads after dataset import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Utilities for working with Amazon Personalize live in `scripts/`:
 - `personalize-setup.js` – initializes dataset groups, datasets, and solutions required by Personalize.
 - `send-event.js` – sends user interaction events to Personalize for model training and real-time recommendations.
 
+### Environment Variables
+
+- `RECORD_KEEP` – number of days to retain local dataset files after they have been uploaded. Files older than this threshold are removed after a successful upload.
+
 ## Testing
 Execute tests (if any are defined):
 ```bash

--- a/scripts/personalize-setup.js
+++ b/scripts/personalize-setup.js
@@ -6,6 +6,8 @@ import {
   CreateDatasetImportJobCommand,
   CreateSolutionCommand
 } from "@aws-sdk/client-personalize";
+import { promises as fs } from "fs";
+import path from "path";
 
 const client = new PersonalizeClient({});
 
@@ -21,6 +23,24 @@ function parseArgs() {
     }
   }
   return args;
+}
+
+async function deleteOldFiles(dir, keepDays) {
+  const cutoff = Date.now() - keepDays * 24 * 60 * 60 * 1000;
+  const entries = await fs.readdir(dir);
+  await Promise.all(
+    entries.map(async (entry) => {
+      const filePath = path.join(dir, entry);
+      try {
+        const stats = await fs.stat(filePath);
+        if (stats.isFile() && stats.mtimeMs < cutoff) {
+          await fs.unlink(filePath);
+        }
+      } catch (err) {
+        // ignore errors for now
+      }
+    })
+  );
 }
 
 async function createSchema() {
@@ -74,6 +94,15 @@ async function createDataset(datasetGroupArn, schemaArn, datasetLocation) {
 
   const { datasetImportJobArn } = await client.send(importCommand);
   console.log(`Dataset import job ARN: ${datasetImportJobArn}`);
+
+  const keep = Number(process.env.RECORD_KEEP);
+  if (!Number.isNaN(keep) && keep > 0 && !datasetLocation.startsWith("s3://")) {
+    try {
+      await deleteOldFiles(path.dirname(datasetLocation), keep);
+    } catch (err) {
+      console.warn("Failed to delete old files", err);
+    }
+  }
 
   return datasetArn;
 }


### PR DESCRIPTION
## Summary
- purge local dataset files older than RECORD_KEEP days after a successful upload
- document RECORD_KEEP environment variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check scripts/personalize-setup.js`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1600d1483289c414fe12ef37eea