### PR TITLE
feat: parse event filenames for S3 key generation

### DIFF
--- a/scripts/build-event-key.js
+++ b/scripts/build-event-key.js
@@ -1,0 +1,15 @@
+export function parseEventFilename(filename) {
+  // Remove extension if provided
+  const base = filename.replace(/\.mp4$/i, '');
+
+  // Expected format: <camera>-YYYYMMDD-HHmmss
+  const match = base.match(/^([^_-]+)[_-](\d{4})(\d{2})(\d{2})[-_]?(\d{2})(\d{2})(\d{2})$/);
+  if (!match) {
+    throw new Error(`Invalid filename format: ${filename}`);
+  }
+  const [ , camera, year, month, day, hour, minute, second ] = match;
+  const date = `${year}-${month}-${day}`;
+  const time = `${hour}:${minute}:${second}`;
+  const key = `events/${camera}/${year}/${month}/${day}/${base}.mp4`;
+  return { camera, date, time, key };
+}

--- a/scripts/build-event-key.test.js
+++ b/scripts/build-event-key.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { parseEventFilename } from './build-event-key.js';
+
+const filename = 'front-20240530-131045.mp4';
+const result = parseEventFilename(filename);
+
+assert.deepEqual(result, {
+  camera: 'front',
+  date: '2024-05-30',
+  time: '13:10:45',
+  key: 'events/front/2024/05/30/front-20240530-131045.mp4'
+});
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add utility to parse camera/date/time from video filename
- generate events S3 key in `events/<camera>/<YYYY>/<MM>/<DD>/<filename>.mp4` format
- include basic unit test for parsing

## Testing
- `node scripts/build-event-key.test.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7b15d1dd883289fb025861efa4e6c