### PR TITLE
Add chokidar watcher for stable file uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "next-video-site",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-personalize": "^3.556.0"
+        "@aws-sdk/client-personalize": "^3.556.0",
+        "chokidar": "^4.0.3"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -1216,6 +1217,21 @@
       "integrity": "sha512-HcOcTudTeEWgbHh0Y1Tyb6fdeR71m4b/QACf0D4KswGTsNeIJQmg38mRENZPAYPZvGFN3fk3604XbQEPdxXdKg==",
       "license": "MIT"
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -1232,6 +1248,19 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@aws-sdk/client-personalize": "^3.556.0"
+    "@aws-sdk/client-personalize": "^3.556.0",
+    "chokidar": "^4.0.3"
   }
 }

--- a/scripts/watch-upload.js
+++ b/scripts/watch-upload.js
@@ -1,0 +1,47 @@
+import chokidar from 'chokidar';
+import { stat } from 'fs/promises';
+
+const WATCH_PATH = process.env.WATCH_PATH || '/mnt';
+const STABLE_ITERATIONS = 2;
+const CHECK_INTERVAL_MS = 1000;
+
+async function waitForStableSize(filePath, interval = CHECK_INTERVAL_MS, stableIterations = STABLE_ITERATIONS) {
+  let lastSize = -1;
+  let stableCount = 0;
+  while (stableCount < stableIterations) {
+    try {
+      const { size } = await stat(filePath);
+      if (size === lastSize) {
+        stableCount += 1;
+      } else {
+        stableCount = 0;
+        lastSize = size;
+      }
+    } catch (err) {
+      // File might not exist yet, reset counters
+      stableCount = 0;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+async function uploadFile(filePath) {
+  // Replace this with real upload logic
+  console.log(`Uploading ${filePath}`);
+}
+
+const watcher = chokidar.watch(WATCH_PATH, {
+  ignoreInitial: true,
+});
+
+watcher.on('add', async (path) => {
+  console.log(`Detected new file: ${path}`);
+  try {
+    await waitForStableSize(path);
+    await uploadFile(path);
+  } catch (err) {
+    console.error(`Failed to upload ${path}`, err);
+  }
+});
+
+console.log(`Watching ${WATCH_PATH} for new files...`);


### PR DESCRIPTION
## Summary
- add chokidar dependency
- implement file watcher that waits for file size to stabilize before upload

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b15c46708328ac4cb8cb2e7e50a8