### PR TITLE
feat: load AWS configuration from environment

### DIFF
--- a/scripts/env.js
+++ b/scripts/env.js
@@ -1,0 +1,21 @@
+export function loadAwsConfig() {
+  const {
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    AWS_REGION,
+    S3_BUCKET,
+    S3_ENDPOINT,
+  } = process.env;
+
+  if (!AWS_ACCESS_KEY_ID || !AWS_SECRET_ACCESS_KEY || !AWS_REGION || !S3_BUCKET) {
+    throw new Error('Missing required AWS environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, S3_BUCKET');
+  }
+
+  return {
+    accessKeyId: AWS_ACCESS_KEY_ID,
+    secretAccessKey: AWS_SECRET_ACCESS_KEY,
+    region: AWS_REGION,
+    bucket: S3_BUCKET,
+    endpoint: S3_ENDPOINT,
+  };
+}

--- a/scripts/personalize-setup.js
+++ b/scripts/personalize-setup.js
@@ -6,8 +6,16 @@ import {
   CreateDatasetImportJobCommand,
   CreateSolutionCommand
 } from "@aws-sdk/client-personalize";
+import { loadAwsConfig } from "./env.js";
 
-const client = new PersonalizeClient({});
+const { accessKeyId, secretAccessKey, region } = loadAwsConfig();
+const client = new PersonalizeClient({
+  region,
+  credentials: {
+    accessKeyId,
+    secretAccessKey,
+  },
+});
 
 function parseArgs() {
   const args = {};


### PR DESCRIPTION
## Summary
- add utility to load AWS and S3 environment variables
- use loaded credentials and region in Personalize setup script

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b15b37b48328930e675575d2afc7