### PR TITLE
Ensure local timezone for Personalize setup

### DIFF
--- a/scripts/personalize-setup.js
+++ b/scripts/personalize-setup.js
@@ -7,6 +7,10 @@ import {
   CreateSolutionCommand
 } from "@aws-sdk/client-personalize";
 
+if (!process.env.TZ) {
+  process.env.TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
 const client = new PersonalizeClient({});
 
 function parseArgs() {


### PR DESCRIPTION
## Summary
- Default `TZ` to the runtime's local timezone

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b146e6ec8328b51d69648b72c256