### PR TITLE
chore: add shared editor and linter config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps maintain consistent coding styles between editors and IDEs
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: ['eslint:recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
+};

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 80,
+};


### PR DESCRIPTION
## Summary
- add root `.editorconfig`
- add shared Prettier configuration
- add shared ESLint configuration

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b122828483289f23ae5c5a55ca27