### PR TITLE
Initialize repo with main branch and comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,41 @@
+# Node dependencies and outputs
 node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+dist/
+build/
+.next/
+out/
+coverage/
+*.tsbuildinfo
 
-# Local env files
+# Local environment files
 .env
+.env.*
+
+# Docker artifacts
+Dockerfile
+Dockerfile.*
+docker-compose.yml
+docker-compose.*.yml
+.docker/
+*.tar
+*.img
+
+# Media outputs
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.flv
+*.wmv
+*.mpg
+*.mpeg
+*.webm
+*.mp3
+*.wav
+*.ogg
+*.m4a
+*.flac


### PR DESCRIPTION
## Summary
- reinitialize repo and set default branch to `main`
- add comprehensive `.gitignore` for Node, Docker, and media outputs

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b7b1189864832892e106361b2ff33f