### PR TITLE
chore: add S3 events bucket policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Utilities for working with Amazon Personalize live in `scripts/`:
 - `personalize-setup.js` – initializes dataset groups, datasets, and solutions required by Personalize.
 - `send-event.js` – sends user interaction events to Personalize for model training and real-time recommendations.
 
+## AWS Permissions
+To upload interaction records to an S3 bucket, attach a policy that allows `s3:PutObject`, `s3:AbortMultipartUpload`, and `s3:ListBucketMultipartUploads` on the `events/*` prefix. An example policy is provided in [`scripts/events-bucket-policy.json`](scripts/events-bucket-policy.json).
+
 ## Testing
 Execute tests (if any are defined):
 ```bash

--- a/scripts/events-bucket-policy.json
+++ b/scripts/events-bucket-policy.json
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:AbortMultipartUpload"
+      ],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/events/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "s3:ListBucketMultipartUploads",
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": "events/*"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document required S3 permissions for uploading events
- add example policy granting PutObject, AbortMultipartUpload, and ListBucketMultipartUploads on `events/*`

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b7b12a4aa88328b22bbea1b44dfaf6