### PR TITLE
Restrict S3 access to events prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,31 @@ Utilities for working with Amazon Personalize live in `scripts/`:
 - `personalize-setup.js` – initializes dataset groups, datasets, and solutions required by Personalize.
 - `send-event.js` – sends user interaction events to Personalize for model training and real-time recommendations.
 
+### IAM Policy
+
+If using Amazon S3 to store interaction data, grant your Personalize role access only to the required prefix. The following policy snippet allows read access to objects under `events/` while restricting bucket listing to the same prefix:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/events/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME",
+      "Condition": {
+        "StringLike": {"s3:prefix": "events/*"}
+      }
+    }
+  ]
+}
+```
+
 ## Testing
 Execute tests (if any are defined):
 ```bash

--- a/scripts/personalize-s3-policy.json
+++ b/scripts/personalize-s3-policy.json
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/events/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": "events/*"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document IAM policy granting S3 GetObject and ListBucket access only to `events/` prefix
- add sample JSON policy for S3 prefix-restricted access

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b12b47c08328a6a971826dcf06ca