### PR TITLE
Allow GET from Vercel and localhost

### DIFF
--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -1,4 +1,16 @@
 export default function handler(req, res) {
+  const origin = req.headers.origin;
+  if (origin && (origin.endsWith('.vercel.app') || origin.startsWith('http://localhost'))) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+  }
+  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Range');
+
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
   res.status(200).json([
     {
       id: 1,


### PR DESCRIPTION
## Summary
- add CORS handling to recommendations API
- allow GET with Content-Type and Range headers for Vercel and localhost

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b12da3748328a8849e62b8b1951c