### PR TITLE
Document R2 signing and add configurable S3 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Utilities for working with Amazon Personalize live in `scripts/`:
 - `personalize-setup.js` – initializes dataset groups, datasets, and solutions required by Personalize.
 - `send-event.js` – sends user interaction events to Personalize for model training and real-time recommendations.
 
+## Storage
+Cloudflare R2 is compatible with Amazon S3 and uses the same AWS Signature Version 4 signing process.
+Provide your R2 endpoint through the `S3_ENDPOINT` environment variable to reuse existing SDK code.
+The helper in `scripts/s3-client.js` builds an `S3Client` that respects this custom endpoint so the
+same code works with either service.
+
 ## Testing
 Execute tests (if any are defined):
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,85 @@
       "name": "next-video-site",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-personalize": "^3.556.0"
+        "@aws-sdk/client-personalize": "^3.556.0",
+        "@aws-sdk/client-s3": "^3.879.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {
@@ -180,6 +258,498 @@
         "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-retry": "^4.0.7",
         "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.879.0.tgz",
+      "integrity": "sha512-1bD2Do/OdCIzl72ncHKYamDhPijUErLYpuLvciyYD4Ywt4cVLHjWtVIqb22XOOHYYHE3NqHMd4uRhvXMlsBRoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/credential-provider-node": "3.879.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.873.0",
+        "@aws-sdk/middleware-expect-continue": "3.873.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.879.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-location-constraint": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-sdk-s3": "3.879.0",
+        "@aws-sdk/middleware-ssec": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.879.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/signature-v4-multi-region": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.879.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.0",
+        "@smithy/eventstream-serde-browser": "^4.0.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.3",
+        "@smithy/eventstream-serde-node": "^4.0.5",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-blob-browser": "^4.0.5",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/hash-stream-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/md5-js": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.19",
+        "@smithy/middleware-retry": "^4.1.20",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.27",
+        "@smithy/util-defaults-mode-node": "^4.0.27",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.7",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.879.0.tgz",
+      "integrity": "sha512-+Pc3OYFpRYpKLKRreovPM63FPPud1/SF9vemwIJfz6KwsBCJdvg7vYD1xLSIp5DVZLeetgf4reCyAA5ImBfZuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.879.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.879.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.19",
+        "@smithy/middleware-retry": "^4.1.20",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.27",
+        "@smithy/util-defaults-mode-node": "^4.0.27",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.879.0.tgz",
+      "integrity": "sha512-AhNmLCrx980LsK+SfPXGh7YqTyZxsK0Qmy18mWmkfY0TSq7WLaSDB5zdQbgbnQCACCHy8DUYXbi4KsjlIhv3PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.9.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.879.0.tgz",
+      "integrity": "sha512-JgG7A8SSbr5IiCYL8kk39Y9chdSB5GPwBorDW8V8mr19G9L+qd6ohED4fAocoNFaDnYJ5wGAHhCfSJjzcsPBVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.879.0.tgz",
+      "integrity": "sha512-2hM5ByLpyK+qORUexjtYyDZsgxVCCUiJQZRMGkNXFEGz6zTpbjfTIWoh3zRgWHEBiqyPIyfEy50eIF69WshcuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.879.0.tgz",
+      "integrity": "sha512-07M8zfb73KmMBqVO5/V3Ea9kqDspMX0fO0kaI1bsjWI6ngnMye8jCE0/sIhmkVAI0aU709VA0g+Bzlopnw9EoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/credential-provider-env": "3.879.0",
+        "@aws-sdk/credential-provider-http": "3.879.0",
+        "@aws-sdk/credential-provider-process": "3.879.0",
+        "@aws-sdk/credential-provider-sso": "3.879.0",
+        "@aws-sdk/credential-provider-web-identity": "3.879.0",
+        "@aws-sdk/nested-clients": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.879.0.tgz",
+      "integrity": "sha512-FYaAqJbnSTrVL2iZkNDj2hj5087yMv2RN2GA8DJhe7iOJjzhzRojrtlfpWeJg6IhK0sBKDH+YXbdeexCzUJvtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.879.0",
+        "@aws-sdk/credential-provider-http": "3.879.0",
+        "@aws-sdk/credential-provider-ini": "3.879.0",
+        "@aws-sdk/credential-provider-process": "3.879.0",
+        "@aws-sdk/credential-provider-sso": "3.879.0",
+        "@aws-sdk/credential-provider-web-identity": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.879.0.tgz",
+      "integrity": "sha512-7r360x1VyEt35Sm1JFOzww2WpnfJNBbvvnzoyLt7WRfK0S/AfsuWhu5ltJ80QvJ0R3AiSNbG+q/btG2IHhDYPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.879.0.tgz",
+      "integrity": "sha512-gd27B0NsgtKlaPNARj4IX7F7US5NuU691rGm0EUSkDsM7TctvJULighKoHzPxDQlrDbVI11PW4WtKS/Zg5zPlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.879.0",
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/token-providers": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.879.0.tgz",
+      "integrity": "sha512-Jy4uPFfGzHk1Mxy+/Wr43vuw9yXsE2yiF4e4598vc3aJfO0YtA2nSfbKD3PNKRORwXbeKqWPfph9SCKQpWoxEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/nested-clients": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+      "integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.876.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.876.0.tgz",
+      "integrity": "sha512-cpWJhOuMSyz9oV25Z/CMHCBTgafDCbv7fHR80nlRrPdPZ8ETNsahwRgltXP1QJJ8r3X/c1kwpOR7tc+RabVzNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+      "integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.879.0.tgz",
+      "integrity": "sha512-DDSV8228lQxeMAFKnigkd0fHzzn5aauZMYC3CSj6e5/qE7+9OwpkUcjHfb7HZ9KWG6L2/70aKZXHqiJ4xKhOZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@smithy/core": "^3.9.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.879.0.tgz",
+      "integrity": "sha512-7+n9NpIz9QtKYnxmw1fHi9C8o0GrX8LbBR4D50c7bH6Iq5+XdSuL5AFOWWQ5cMD0JhqYYJhK/fJsVau3nUtC4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.876.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.879.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.879.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.879.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.9.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.19",
+        "@smithy/middleware-retry": "^4.1.20",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.27",
+        "@smithy/util-defaults-mode-node": "^4.0.27",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+      "integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.879.0.tgz",
+      "integrity": "sha512-47J7sCwXdnw9plRZNAGVkNEOlSiLb/kR2slnDIHRK9NB/ECKsoqgz5OZQJ9E2f0yqOs8zSNJjn3T01KxpgW8Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/nested-clients": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.879.0.tgz",
+      "integrity": "sha512-aVAJwGecYoEmbEFju3127TyJDF9qJsKDUUTRMDuS8tGn+QiWQFnfInmbt+el9GU1gEJupNTXV+E3e74y51fb7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-endpoints": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+      "integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.879.0.tgz",
+      "integrity": "sha512-A5KGc1S+CJRzYnuxJQQmH1BtGsz46AgyHkqReKfGiNQA8ET/9y9LQ5t2ABqnSBHHIh3+MiCcQSkUZ0S3rTodrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -398,6 +968,102 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.873.0.tgz",
+      "integrity": "sha512-b4bvr0QdADeTUs+lPc9Z48kXzbKHXQKgTvxx/jXDgSW9tv4KmYPO1gIj6Z9dcrBkRWQuUtSW3Tu2S5n6pe+zeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.873.0.tgz",
+      "integrity": "sha512-GIqoc8WgRcf/opBOZXFLmplJQKwOMjiOMmDz9gQkaJ8FiVJoAp8EGVmK2TOWZMQUYsavvHYsHaor5R2xwPoGVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.879.0.tgz",
+      "integrity": "sha512-U1rcWToy2rlQPQLsx5h73uTC1XYo/JpnlJGCc3Iw7b1qrK8Mke4+rgMPKCfnXELD5TTazGrbT03frxH4Y1Ycvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.879.0.tgz",
+      "integrity": "sha512-AhNmLCrx980LsK+SfPXGh7YqTyZxsK0Qmy18mWmkfY0TSq7WLaSDB5zdQbgbnQCACCHy8DUYXbi4KsjlIhv3PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.9.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz",
@@ -406,6 +1072,20 @@
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
         "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.873.0.tgz",
+      "integrity": "sha512-r+hIaORsW/8rq6wieDordXnA/eAu7xAPLue2InhoEX6ML7irP52BgiibHLpt9R0psiCzIHhju8qqKa4pJOrmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -435,6 +1115,84 @@
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
         "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.879.0.tgz",
+      "integrity": "sha512-ZTpLr2AbZcCsEzu18YCtB8Tp8tjAWHT0ccfwy3HiL6g9ncuSMW+7BVi1hDYmBidFwpPbnnIMtM0db3pDMR6/WA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/core": "^3.9.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.879.0.tgz",
+      "integrity": "sha512-AhNmLCrx980LsK+SfPXGh7YqTyZxsK0Qmy18mWmkfY0TSq7WLaSDB5zdQbgbnQCACCHy8DUYXbi4KsjlIhv3PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.9.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.5.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.873.0.tgz",
+      "integrity": "sha512-AF55J94BoiuzN7g3hahy0dXTVZahVi8XxRBLgzNp6yQf0KTng+hb/V9UQZVYY1GZaDczvvvnqC54RGe9OZZ9zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -526,6 +1284,23 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.879.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.879.0.tgz",
+      "integrity": "sha512-MDsw0EWOHyKac75X3gD8tLWtmPuRliS/s4IhWRhsdDCU13wewHIs5IlA5B65kT6ISf49yEIalEH3FHUSVqdmIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.879.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz",
@@ -551,6 +1326,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
+      "integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -647,6 +1434,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
+      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
+      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
@@ -664,9 +1476,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
-      "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.9.1.tgz",
+      "integrity": "sha512-E3erEn1SjPq8P9w2fPlp1+slaq6FlrRKlsaLCo0aPMY2j94lwZlwz1yqY4yDeX3+ViG+sOEPPRBZGfdciMtABA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.9",
@@ -701,6 +1513,76 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+      "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.5.tgz",
+      "integrity": "sha512-LCUQUVTbM6HFKzImYlSB9w4xafZmpdmZsOh9rIl7riPC3osCgGFVP+wwvYVw6pXda9PPT9TcEZxaq3XE81EdJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.3.tgz",
+      "integrity": "sha512-yTTzw2jZjn/MbHu1pURbHdpjGbCuMHWncNBpJnQAPxOVnFUAbSIUSwafiphVDjNV93TdBJWmeVAds7yl5QCkcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.5.tgz",
+      "integrity": "sha512-lGS10urI4CNzz6YlTe5EYG0YOpsSp3ra8MXyco4aqSkQDuyZPIw2hcaxDU82OUVtK7UY9hrSvgWtpsW5D4rb4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.5.tgz",
+      "integrity": "sha512-JFnmu4SU36YYw3DIBVao3FsJh4Uw65vVDIqlWT4LzR6gXA0F3KP0IXFKKJrhaVzCBhAuMsrUUaT5I+/4ZhF7aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
@@ -717,6 +1599,21 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.5.tgz",
+      "integrity": "sha512-F7MmCd3FH/Q2edhcKd+qulWkwfChHbc9nhguBlVjSUE6hVHhec3q6uPQ+0u69S6ppvLtR3eStfCuEKMXBXhvvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.0.0",
+        "@smithy/chunked-blob-reader-native": "^4.0.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/hash-node": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
@@ -725,6 +1622,20 @@
       "dependencies": {
         "@smithy/types": "^4.3.2",
         "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.5.tgz",
+      "integrity": "sha512-IJuDS3+VfWB67UC0GU0uYBG/TA30w+PlOaSo0GPm9UHS88A6rCP6uZxNjNYiyRtOcjv7TXn/60cW8ox1yuZsLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -757,6 +1668,20 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.5.tgz",
+      "integrity": "sha512-8n2XCwdUbGr8W/XhMTaxILkVlw2QebkVTn5tm3HOcbPbOpWg89zr6dPXsH8xbeTsbTXlJvlJNTQsKAIoqQGbdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
@@ -772,12 +1697,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
-      "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
+      "version": "4.1.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.20.tgz",
+      "integrity": "sha512-6jwjI4l9LkpEN/77ylyWsA6o81nKSIj8itRjtPpVqYSf+q8b12uda0Upls5CMSDXoL/jY2gPsNj+/Tg3gbYYew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.8.0",
+        "@smithy/core": "^3.9.1",
         "@smithy/middleware-serde": "^4.0.9",
         "@smithy/node-config-provider": "^4.1.4",
         "@smithy/shared-ini-file-loader": "^4.0.5",
@@ -791,15 +1716,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
-      "integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
+      "version": "4.1.21",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.21.tgz",
+      "integrity": "sha512-oFpp+4JfNef0Mp2Jw8wIl1jVxjhUU3jFZkk3UTqBtU5Xp6/ahTu6yo1EadWNPAnCjKTo8QB6Q+SObX97xfMUtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
         "@smithy/protocol-http": "^5.1.3",
         "@smithy/service-error-classification": "^4.0.7",
-        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/smithy-client": "^4.5.1",
         "@smithy/types": "^4.3.2",
         "@smithy/util-middleware": "^4.0.5",
         "@smithy/util-retry": "^4.0.7",
@@ -967,13 +1892,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
-      "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.5.1.tgz",
+      "integrity": "sha512-PuvtnQgwpy3bb56YvHAP7eRwp862yJxtQno40UX9kTjjkgTlo//ov+e1IVCFTiELcAOiqF2++Y0e7eH/Zgv5Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.8.0",
-        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/core": "^3.9.1",
+        "@smithy/middleware-endpoint": "^4.1.20",
         "@smithy/middleware-stack": "^4.0.5",
         "@smithy/protocol-http": "^5.1.3",
         "@smithy/types": "^4.3.2",
@@ -1074,13 +1999,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
-      "integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.28.tgz",
+      "integrity": "sha512-83Iqb9c443d8S/9PD6Bb770Q3ZvCenfgJDoR98iveI+zKpu6d4mOVS2RKBU9Z4VQPbRcrRj71SY0kZePGh+wZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/smithy-client": "^4.5.1",
         "@smithy/types": "^4.3.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -1090,16 +2015,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
-      "integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
+      "version": "4.0.28",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.28.tgz",
+      "integrity": "sha512-LzklW4HepBM198vH0C3v+WSkMHOkxu7axCEqGoKdICz3RHLq+mDs2AkDDXVtB61+SHWoiEsc6HOObzVQbNLO0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.5",
         "@smithy/credential-provider-imds": "^4.0.7",
         "@smithy/node-config-provider": "^4.1.4",
         "@smithy/property-provider": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/smithy-client": "^4.5.1",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -1198,6 +2123,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.7.tgz",
+      "integrity": "sha512-mYqtQXPmrwvUljaHyGxYUIIRI3qjBTEb/f5QFi3A6VlxhpmZd5mWXn9W+qUkf2pVE1Hv3SqxefiZOPGdxmO64A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.0.5",
+        "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@aws-sdk/client-personalize": "^3.556.0"
+    "@aws-sdk/client-personalize": "^3.556.0",
+    "@aws-sdk/client-s3": "^3.879.0"
   }
 }

--- a/scripts/s3-client.js
+++ b/scripts/s3-client.js
@@ -1,0 +1,18 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+/**
+ * Create an S3-compatible client. Supports Cloudflare R2 by allowing a custom
+ * endpoint via the S3_ENDPOINT environment variable. R2 uses the same signing
+ * mechanism (AWS Signature Version 4) as Amazon S3.
+ */
+export function createS3Client() {
+  return new S3Client({
+    region: process.env.AWS_REGION || "us-east-1",
+    endpoint: process.env.S3_ENDPOINT,
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- document that Cloudflare R2 uses the same signing as Amazon S3 and note how to set a custom endpoint
- add an S3 client helper that honors an `S3_ENDPOINT` for R2 compatibility
- include S3 client dependency

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b7b13b541c8328b37843209bb4c1f2